### PR TITLE
Optimize. Prevent redundant re-render

### DIFF
--- a/src/WinXP/Windows/index.js
+++ b/src/WinXP/Windows/index.js
@@ -23,7 +23,7 @@ function Windows({
       isFocus={focusedAppId === app.id}
       {...app}
     >
-      <app.component onClose={onClose.bind(null, app.id)} />
+      <app.component id={app.id} onClose={onClose} />
     </StyledWindow>
   ));
 }

--- a/src/WinXP/apps/ErrorBox/index.js
+++ b/src/WinXP/apps/ErrorBox/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import error from 'src/assets/windowsIcons/897(32x32).png';
 
-function Error({ onClose, className }) {
+function Error({ id, onClose, className }) {
   return (
     <div className={className}>
       <div className="error__top">
@@ -14,7 +14,7 @@ function Error({ onClose, className }) {
         </div>
       </div>
       <div className="error__bottom">
-        <div onClick={onClose} className="error__button">
+        <div onClick={()=>onClose(id)} className="error__button">
           <span>OK</span>
         </div>
       </div>

--- a/src/WinXP/apps/InternetExplorer/index.js
+++ b/src/WinXP/apps/InternetExplorer/index.js
@@ -22,7 +22,7 @@ import dropdown from 'src/assets/windowsIcons/dropdown.png';
 import { WindowDropdown, Google } from 'src/components';
 import dropDownData from './dropDownData';
 
-function InternetExplorer({ onClose }) {
+function InternetExplorer({ id,onClose }) {
   const dropDown = useRef(null);
   const [state, setState] = useState({
     route: 'main',
@@ -52,7 +52,7 @@ function InternetExplorer({ onClose }) {
   function onClickOptionItem(item) {
     switch (item) {
       case 'Close':
-        onClose();
+        onClose(id);
         break;
       case 'Home Page':
       case 'Back':
@@ -543,4 +543,4 @@ const Div = styled.div`
   }
 `;
 
-export default InternetExplorer;
+export default React.memo(InternetExplorer);

--- a/src/WinXP/apps/Minesweeper/MinesweeperView.js
+++ b/src/WinXP/apps/Minesweeper/MinesweeperView.js
@@ -93,6 +93,7 @@ function MineSweeperView({
   mines,
   status,
   seconds,
+  id,
   onClose,
   difficulty,
   openingCeil,
@@ -186,7 +187,7 @@ function MineSweeperView({
   function onClickOptionItem(item) {
     switch (item) {
       case 'Exit':
-        onClose();
+        onClose(id);
         break;
       case 'Beginner':
       case 'Intermediate':

--- a/src/WinXP/apps/Minesweeper/index.js
+++ b/src/WinXP/apps/Minesweeper/index.js
@@ -152,7 +152,7 @@ function reducer(state, action = {}) {
   }
 }
 
-function MineSweeper({ defaultDifficulty, onClose }) {
+function MineSweeper({ defaultDifficulty,id, onClose }) {
   const [state, dispatch] = useReducer(
     reducer,
     getInitState(defaultDifficulty),
@@ -232,6 +232,7 @@ function MineSweeper({ defaultDifficulty, onClose }) {
   return (
     <MinesweeperView
       {...state}
+      id={id}
       onClose={onClose}
       changeCeilState={changeCeilState}
       openCeil={openCeil}
@@ -349,4 +350,4 @@ function useTimer(status) {
   return seconds;
 }
 
-export default MineSweeper;
+export default React.memo(MineSweeper);

--- a/src/WinXP/apps/MyComputer/index.js
+++ b/src/WinXP/apps/MyComputer/index.js
@@ -27,7 +27,7 @@ import mine from 'src/assets/minesweeper/mine-icon.png';
 import { WindowDropdown } from 'src/components';
 import dropDownData from './dropDownData';
 
-function MyComputer({ onClose }) {
+function MyComputer({id, onClose }) {
   const dropDown = useRef(null);
   const [openOption, setOpenOption] = useState('');
   function hoverOption(option) {
@@ -39,7 +39,7 @@ function MyComputer({ onClose }) {
   function onClickOptionItem(item) {
     switch (item) {
       case 'Close':
-        onClose();
+        onClose(id);
         break;
       default:
     }
@@ -847,4 +847,4 @@ const Div = styled.div`
   }
 `;
 
-export default MyComputer;
+export default React.memo(MyComputer);

--- a/src/WinXP/index.js
+++ b/src/WinXP/index.js
@@ -178,11 +178,12 @@ function WinXP() {
       dispatch({ type: FOCUS_APP, payload: id });
     }
   }
-  function onCloseApp(id) {
-    if (getFocusedAppId() === id && state.focusing === FOCUSING.WINDOW) {
-      dispatch({ type: DEL_APP, payload: id });
-    }
-  }
+  const onCloseApp = React.useCallback(
+    function onCloseApp(id) {
+      if (getFocusedAppId() === id && state.focusing === FOCUSING.WINDOW) {
+        dispatch({ type: DEL_APP, payload: id });
+      }
+    },[state.apps])
   function onMouseDownIcon(id) {
     dispatch({ type: FOCUS_ICON, payload: id });
   }


### PR DESCRIPTION
1. In each `<App>`(eg. ErrorBox / MyComputer... ), use React.memo to optimize each app components. (prevent redundant re-render)
2. In `<WinXP>`, use React.useCallback to make sure `onClose` method will only change when apps state be changed. (The close function of `<Window>` depends on `focusAppID`, which depends on apps state)
3. To make sure the `onClose` method not change in child component (`<Windows>`), I remove dynamic bind (seems it cause `onClose` change),and drill the id prop to relative app. (Like you pass `app.id` from windows to window)
