### PR TITLE
remove winamp when starting up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea/*

--- a/src/WinXP/apps/index.js
+++ b/src/WinXP/apps/index.js
@@ -68,27 +68,6 @@ export const defaultAppState = [
     zIndex: genIndex(),
   },
   {
-    component: Winamp,
-    header: {
-      title: 'Winamp',
-      icon: winamp,
-      invisible: true,
-    },
-    defaultSize: {
-      width: 0,
-      height: 0,
-    },
-    defaultOffset: {
-      x: 0,
-      y: 0,
-    },
-    resizable: false,
-    minimized: false,
-    maximized: false,
-    id: genId(),
-    zIndex: genIndex(),
-  },
-  {
     component: MyComputer,
     header: {
       title: 'My Computer',


### PR DESCRIPTION
related to #60 

For me WinAmp is not a program I need when starting up. When I need it, I can open it by double clicking it's icon.