### PR TITLE
Fix Minesweeper score and time wrapping

### DIFF
--- a/src/WinXP/apps/Minesweeper/MinesweeperView.js
+++ b/src/WinXP/apps/Minesweeper/MinesweeperView.js
@@ -367,6 +367,7 @@ export default styled(MineSweeperView)`
     border-width: 0 1px 1px 0;
     border-style: solid;
     border-color: #fff;
+    display: flex;
     text-align: right;
   }
   .mine__face__outer {


### PR DESCRIPTION
The numbers are stacking though there's enough horizontal space for them. Switching to a flex container keeps them on the same row.

https://github.com/ShizukuIchi/winXP/assets/6905903/66340dbe-345a-470d-ab15-3d59b35ecbc6

