### PR TITLE
Fix spelling in Internet Explorer window title

### DIFF
--- a/src/WinXP/apps/index.js
+++ b/src/WinXP/apps/index.js
@@ -159,7 +159,7 @@ export const appSettings = {
   'Internet Explorer': {
     header: {
       icon: iePaper,
-      title: 'InternetExplorer',
+      title: 'Internet Explorer',
     },
     component: InternetExplorer,
     defaultSize: {


### PR DESCRIPTION
This PR fixes the spelling in the Internet Explorer window title when opening a new instance of Internet Explorer.

When the page first opens, the title in the Internet Explorer window is written as `Internet Explorer`, which is the expected spelling. But when you open Internet Explorer by double-clicking on the desktop shortcut, the window title is `InternetExplorer` (without the space).